### PR TITLE
Update linuxprivchecker.sh

### DIFF
--- a/linuxprivchecker.sh
+++ b/linuxprivchecker.sh
@@ -133,6 +133,9 @@ userENVIRONMENT(){
   systemNAME="Sudoers Files (Privileged) [/etc/sudoers.d/*]";
   cmdRESPONSE "cat /etc/sudoers.d/* | grep -v '#'";
 
+  systemNAME="User's specific NOPASSWD sudo entries";
+  cmdRESPONSE "sudo -ln";
+
   systemNAME="Root and Current User History (depends on privs)";
   cmdRESPONSE "ls -al ~/.*_history 2>/dev/null; ls -la /root/.*_history";
 

--- a/linuxprivchecker.sh
+++ b/linuxprivchecker.sh
@@ -1,252 +1,251 @@
 #!/bin/bash
-
 ###############################################################################################################
 ## [Title]: linuxprivchecker.sh -- a Linux Privilege Escalation Check Script
-## [Author]: Mike Czumak (T_v3rn1x) -- @SecuritySift
-## [Contributors]: Mike Merrill (linted) -- https://github.com/linted
-## 		   James Hogan (5aru) -- https://github.com/5aru
+## [Original Author]: Mike Czumak (T_v3rn1x) -- https://twitter.com/SecuritySift
+## Forked from linuxprivchecker.py -- https://github.com/sleventyeleven/linuxprivchecker
+## [Contributors]:
+## Mike Merrill (linted) -- https://github.com/linted
+## James Hogan (5aru) -- https://github.com/5aru
+## Ali Kaba (alibkaba) -- https://github.com/alibkaba
 ##-------------------------------------------------------------------------------------------------------------
-## [Details]: 
-## Similar functions to Mike Czumak's linuxprivchecker.py Linux Privilege Escalation Check Script.
-## This script is intended to be executed locally on a Linux box to enumerate basic system info and 
+## [Details]:
+## This script is intended to be executed locally on a Linux box to enumerate basic system info and
 ## search for common privilege escalation vectors such as world writable files, misconfigurations, clear-text
-## passwords and applicable exploits. 
+## passwords and applicable exploits.
 ##-------------------------------------------------------------------------------------------------------------
 ## [Warning]:
 ## This script comes as-is with no promise of functionality or accuracy.
-##-------------------------------------------------------------------------------------------------------------   
+##-------------------------------------------------------------------------------------------------------------
 ## [Modification, Distribution, and Attribution]:
-## Permission is herby granted, free of charge, to any person obtaining a copy of this software and the 
-## associated documentation files (the "Software"), to use, copy, modify, merge, publish, distribute, and/or 
+## Permission is herby granted, free of charge, to any person obtaining a copy of this software and the
+## associated documentation files (the "Software"), to use, copy, modify, merge, publish, distribute, and/or
 ## sublicense copies of the Software, and to permit persons to whom the Software is furnished to do so, subject
 ## to the following conditions:
 ##
 ## The software must maintain original author attribution and may not be sold
 ## or incorporated into any commercial offering.
 ##
-## THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR ## IMPLIED, INCLUDING BUT NOT 
-## LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO 
-## EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER 
+## THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR ## IMPLIED, INCLUDING BUT NOT
+## LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+## EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER
 ## IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 ## USE OR OTHER DEALINGS IN THE SOFTWARE.
 ###############################################################################################################
 
-### Useful functions
-
+# command paths
 PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/games:/usr/games"
 
-TITLE_LINE=$(printf "%*s\n" "80" | tr ' ' "=")
-SECTION_LINE=$(printf "%*s\n" "80" | tr ' ' "-")
+# line formatting
+titleLINE=$(printf "%*s\n" "80" | tr ' ' "=");
+sectionLINE=$(printf "%*s\n" "40" | tr ' ' "-");
 
-function formatCommand(){
-	eval $1 | sed 's|^|    |'
+# title
+scriptTITLE(){
+echo ${titleLINE};
+echo "         LINUX PRIVILEGE ESCALATION CHECKER"
+echo "         https://github.com/linted/linuxprivchecker for more info..."
+echo ${titleLINE};
 }
 
-echo ${TITLE_LINE}
-echo "LINUX_PRIVILEGE ESCALATION CHECKER"
-echo ${TITLE_LINE}
+systemAREAtitle(){
+  echo ${sectionLINE};
+  echo -e "         $systemAREA";
+  echo ${sectionLINE};
+  echo
+  sleep .5s;
+}
 
-echo -e "\n[*] GETTING BASIC SYSTEM INFO...\n"
+cmdRESPONSE(){
+	# run and format cmd
+  cmdRESULT=$(eval $1 2>/dev/null | sed 's|^|           |'; echo "${PIPESTATUS[0]}");
 
-echo "[+] Operating System"
-formatCommand "cat /etc/issue"
+	# check cmd status
+  if [ ${cmdRESULT:(-1)} -eq 0 ]; then
+    echo "[OK]     $systemNAME";
+    echo "${cmdRESULT%?}";
+    echo
+  else
+    echo "[FAILED] $systemNAME";
+    echo "${cmdRESULT%?}";
+    echo
+  fi
+  sleep .5s;
+}
 
-echo -e "\n[+] Kernel"
-formatCommand "cat /proc/version"
+operatingSYSTEM(){
+  systemAREA="OPERATING SYSTEM";
+  systemAREAtitle;
 
-echo -e "\n[+] Hostname/FQDN"
-formatCommand "hostname -f"
+  systemNAME="Distribution";
+  cmdRESPONSE "cat /etc/*-release";
 
-echo -ne "\n${SECTION_LINE}\n"
-echo -e "[*] GETTING NETWORKING INFO...\n"
+  systemNAME="Kernel";
+  cmdRESPONSE "if [ -f /proc/version ]; then cat /proc/version; else uname -a; fi";
 
-echo "[+] Route"
+  systemNAME="Hostname";
+  cmdRESPONSE "hostname -f";
+}
 
-if [ -x "$(command -v route)" ]; then
-	formatCommand "route -n"
-else
-	formatCommand "ip route"
-fi
+netWORK(){
+  systemAREA="NETWORK";
+  systemAREAtitle;
 
-echo -e "\n[+] Interfaces"
+  systemNAME="Network Interfaces";
+  cmdRESPONSE "ifconfig || ip a";
 
-if [ -x "$(command -v ifconfig)" ]; then
-	formatCommand "ifconfig -a"
-else
-	formatCommand "ip addr show"
-fi
+  systemNAME="DNS Resolver";
+  cmdRESPONSE "cat /etc/resolv.conf";
 
-echo -e "\n[+] Network Connections"
+  systemNAME="Route";
+  cmdRESPONSE "route -n || ip route";
+}
 
-if [ -x "$(command -v netstat)" ]; then
-	formatCommand "netstat -tupan | grep -v TIME_WAIT"
-else
-	formatCommand "ss -tupan | grep -v CLOSE_WAIT"
-fi
+userENVIRONMENT(){
+  systemAREA="USERS & ENVIRONMENT";
+  systemAREAtitle;
 
-echo -ne "\n${SECTION_LINE}\n"
-echo -e "[*] GETTING FILESYSTEM INFO...\n"
+  systemNAME="Current User";
+  cmdRESPONSE "whoami";
 
-echo -e "\n[+] Mount Results"
-formatCommand "mount"
+  systemNAME="Current User ID";
+  cmdRESPONSE "id";
 
-echo -e "\n[+] fstab Entries"
-formatCommand "cat /etc/fstab 2>/dev/null"
+  systemNAME="Who's Logged Right Now";
+  cmdRESPONSE "w";
 
-echo -e "\n[+] Scheduled cron jobs"
-formatCommand "ls -al /etc/cron* 2>/dev/null"
+  systemNAME="Who's Logged Last";
+  cmdRESPONSE "last";
 
-echo -e "\n[+] Writable cron directories"
-formatCommand "ls -aRl /etc/cron* 2>/dev/null | awk '$1 ~ /w.$' 2>/dev/null"
+  systemNAME="All Users";
+  cmdRESPONSE "cat /etc/passwd";
 
-echo -ne "\n${SECTION_LINE}\n"
-echo -e "[*] ENUMERATING USER AND ENVIRONMENTAL INFO...\n"
-echo -e "\n[+] Current User"
-formatCommand "whoami"
+  systemNAME="All Groups";
+  cmdRESPONSE "cat /etc/group";
 
-echo -e "\n[+] Current User ID"
-formatCommand "id"
+  systemNAME="Shadow File";
+  cmdRESPONSE "cat /etc/shadow";
 
-echo -e "\n[+] All users"
-formatCommand "cat /etc/passwd"
+  systemNAME="Super Users";
+  cmdRESPONSE "grep -v -E '^#' /etc/passwd | awk -F: '(/$3 == 0) { print /$1 }'";
 
-echo -e "\n[+] Super Users Found"
-formatCommand "grep -v -E '^#' /etc/passwd | awk -F: '\$3 == 0{print \$1}'"
+  systemNAME="Sudo Users";
+  cmdRESPONSE "cat /etc/sudoers | grep -v '#'";
 
-echo -e "\n[+] Root and current user history (depends on privs)"
-formatCommand "ls -al ~/.*_history; ls -la /root/.*_history 2>/dev/null"
+  systemNAME="Sudoers (Privileged) [/etc/sudoers]";
+  cmdRESPONSE "cat /etc/sudoers | grep -v '#'";
 
-echo -e "\n[+] Environment Variables"
-formatCommand "env 2>/dev/null | grep -v 'LS_COLORS'"
+  systemNAME="Sudoers Files (Privileged) [/etc/sudoers.d/*]";
+  cmdRESPONSE "cat /etc/sudoers.d/* | grep -v '#'";
 
-echo -e "\n[+] Sudoers (Privileged) [/etc/sudoers]"
-formatCommand "cat /etc/sudoers 2>/dev/null | grep -v '#' 2>/dev/null"
+  systemNAME="Root and Current User History (depends on privs)";
+  cmdRESPONSE "ls -al ~/.*_history 2>/dev/null; ls -la /root/.*_history";
 
-echo -e "\n[+] Sudoers Files (Privileged) [/etc/sudoers.d/*]"
-formatCommand "cat /etc/sudoers.d/* 2>/dev/null | grep -v '#' 2>/dev/null"
+  systemNAME="Environment Variables";
+  cmdRESPONSE "env | grep -v "LS_COLORS"";
 
-echo -e "\n[+] Logged in User Activity"
-formatCommand "w 2>/dev/null"
+  systemNAME="Printer";
+  cmdRESPONSE "lpstat -a";
+}
 
-echo -ne "\n${SECTION_LINE}\n"
-echo -e "[*] ENUMERATING FILE AND DIRECTORY PERMISSIONS/CONTENTS...\n"
+filePERMISSIONS(){
+  systemAREA="FILE SYSTEMS & PERMISSIONS";
+  systemAREAtitle;
 
-echo -e "\n[+] World Writable Directories for User/Group 'root'"
-formatCommand "find / \( -wholename '/home/homedir*' -prune \) -o \( -type d -perm -0002 \) -exec ls -ld '{}' ';' 2>/dev/null | grep root"
+  systemNAME="Mounts";
+  cmdRESPONSE "mount";
 
-echo -e "\n[+] World Writable Directories for User other than 'root'"
-formatCommand "find / \( -wholename '/home/homedir*' -prune \) -o \( -type d -perm -0002 \) -exec ls -ld '{}' ';' 2>/dev/null"
+  systemNAME="fstab Entries";
+  cmdRESPONSE "cat /etc/fstab";
 
-echo -e "\n[+] World Writable Files"
-formatCommand "find / \( -wholename '/home/homedir/*' -prune -o -wholename '/proc/*' -prune \) -o \( -type f -perm -0    002 \) -exec ls -l '{}' ';' 2>/dev/null"
+  systemNAME="Scheduled Cron Jobs";
+  cmdRESPONSE "ls -al /etc/cron*";
 
-echo -e "\n[+] SUID/GUID Files and Directories"
-formatCommand "find / \( -perm -2000 -o -perm -4000 \) -exec ls -ld {} \; 2>/dev/null"
+  systemNAME="Writable Cron Directories";
+  cmdRESPONSE "ls -aRl /etc/cron* | awk '/$1 ~ /w.$'";
 
-echo -e "\n[+] Checking if root's home folder is accessible"
-formatCommand "ls -ahlR /root 2>/dev/null"
+  systemNAME="Root Home Folder Accessibility";
+  cmdRESPONSE "ls -lt /root/";
 
-echo -e "\n[+] Logs containing keyword 'password'"
-formatCommand "find /var/log -name '*.log' 2>/dev/null | xargs -l10 egrep 'pwd|password' 2>/dev/null"
+  systemNAME="World Writeables Directories for User/Group 'root'";
+  cmdRESPONSE "find / \( -wholename '/home/homedir*' -prune \) -o \( -type d -perm -o+w \) -exec ls -ld '{}' ';' | grep root";
 
-echo -e "\n[+] Config files containing keyword 'password'"
-formatCommand "find /etc -name '*.c*' 2>/dev/null | xargs -l10 egrep 'pwd|password' 2>/dev/null"
+  systemNAME="World Writeables Directories for non-root Users";
+  cmdRESPONSE "find / \( -wholename '/home/homedir*' -prune \) -o \( -type d -perm -0002 \) -exec ls -ld '{}' ';' | grep -v root ";
 
-echo -e "\n[+] Shadow Files (Privileged)"
-formatCommand "cat /etc/shadow 2>/dev/null"
+  systemNAME="World Writeables Files";
+  cmdRESPONSE "find / \( -wholename '/home/homedir/*' -prune -o -wholename '/proc/*' -prune \) -o \( -type f -perm -0    002 \) -exec ls -l '{}' ';'";
 
-echo -ne "\n${SECTION_LINE}\n"
-echo -e "[*] ENUMERATING PROCESSES AND APPLICATIONS...\n"
+  systemNAME="SUID/GUID Files and Directories";
+  cmdRESPONSE "ls -ahlR /root";
 
-echo -e "[+] Installed Packages"
-if [ -x "$(command -v dpkg)" ]; then
-	PKGMNGR=1
-	formatCommand "dpkg -l | awk '{\$1=\$4=\"\"; print \$0}'"
-elif [ -x "$(command -v dnf)" ]; then
-	PKGMNGR=2
-	formatCommand "dnf -qa | sort -u"
-elif [ -x "$(command -v rpm)" ]; then
-	PKGMNGR=3
-	formatCommand "rpm -qa | sort -u"
-fi
+  systemNAME="Configuration Files Containing Keyword 'password'";
+  cmdRESPONSE "find /var/log -name '*.log' | xargs -l10 egrep 'pwd|password' 2>/dev/null";
+}
 
-echo -e "\n[+] Current Processes"
-formatCommand "ps aux | awk '{print \$1,\$2,\$9,\$10,\$11}'"
+applicationSERVICES(){
+  systemAREA="APPLICATIONS & SERVICES";
+  systemAREAtitle;
 
-echo -e "\n[+] Sudo Version"
-formatCommand "sudo -V | grep version 2>/dev/null"
+  systemNAME="Installed Packages";
+  cmdRESPONSE "if [ -x "$(command -v dpkg)" ]; then dpkg -l | awk '{\$1=\$4=\"\"; print \$0}'; elif [ -x "$(command -v dnf)" ]; then dnf -qa | sort -u; elif [ -x "$(command -v rpm)" ]; then rpm -qa | sort -u; fi";
 
-echo -e "\n[+] Apache Version and Modules"
-formatCommand "apache2 -v 2>/dev/null; apache2ctl -M 2>/dev/null; httpd -v 2>/dev/null; apachectl -l 2>/dev/null"
+  systemNAME="Current Running Services";
+  cmdRESPONSE "ps aux | awk '{print \$1,\$2,\$9,\$10,\$11}'";
 
-echo -e "\n[+] Apache Config File"
-formatCommand "cat /etc/apache2/apache2.conf 2>/dev/null"
+  systemNAME="Bash version";
+  cmdRESPONSE "bash --version | grep version";
 
-echo -ne "\n${SECTION_LINE}\n"
-echo -e "[*] IDENTIFYING PROCESSES AND PACKAGES RUNNING AS ROOT OR OTHER SUPERUSER...\n"
+  systemNAME="Sudo version";
+  cmdRESPONSE "sudo -V | grep version";
 
-EXTDGREP="($(ps -u 0 | tail -n+2 | rev | cut -d " " -f 1 | rev | cut -d "/" -f1 | sort | uniq | xargs | tr " " "|"))"
+  systemNAME="Apache Version and Modules";
+  cmdRESPONSE "apache2 -v 2>/dev/null; apache2ctl -M 2>/dev/null; httpd -v 2>/dev/null; apachectl -l";
 
-if [ $PKGMNGR -eq 1 ]; then
-    	formatCommand "dpkg -l | grep -iE '${EXTDGREP}'"
-elif [ $PKGMNGR -eq 2 ]; then
-	formatCommand "dnf -qa | grep -iE '${EXTDGREP}'"
-elif [ $PKGMNGR -eq 3 ]; then
-	formatCommand "rpm -qa | grep -iE '${EXTDGREP}'"
-fi
+  systemNAME="Apache Config File";
+  cmdRESPONSE "cat /etc/apache2/apache2.conf";
 
-echo -ne "\n${SECTION_LINE}\n"
-echo -e "[*] ENUMERATING INSTALLED LANGUAGES/TOOLS FOR SPLOIT BUILDING..."
+  systemNAME="Processes and Packages Running as Root or other Superuser";
+  EXTDGREP="($(ps -u 0 | tail -n+2 | rev | cut -d " " -f 1 | rev | cut -d "/" -f1 | sort | uniq | xargs | tr " " "|"))";
+  cmdRESPONSE "if [ -x "$(command -v dpkg)" ]; then dpkg -l | grep -iE '${EXTDGREP}'; elif [ -x "$(command -v dnf)" ]; then dnf -qa | grep -iE '${EXTDGREP}'; elif [ -x "$(command -v rpm)" ]; then rpm -qa | grep -iE '${EXTDGREP}'; fi";
 
-echo -e "\n[+] Installed Tools"
-formatCommand "which awk perl python ruby gcc cc vi vim nmap find netcat nc wget tftp ftp 2>/dev/null"
+  systemNAME="Installed Tools";
+  cmdRESPONSE "which awk perl python ruby gcc cc vi vim nmap find netcat nc wget tftp ftp";
 
-echo -e "\n[+] Related Shell Escape Sequences"
-if [ -x "$(command -v vi)" ]; then
-	formatCommand "echo -ne \"vi-->\t:!bash\n\""
-	formatCommand "echo -ne \"vi-->\t:set shell=/bin/bash:shell\n\""
-fi
+  systemNAME="Related Shell Escape Sequences";
+  cmdRESPONSE "if [ -x "$(command -v vi)" ]; then echo -ne \"vi-->\t:!bash\n\"; echo -ne \"vi-->\t:set shell=/bin/bash:shell\n\"; fi; if [ -x "$(command -v vim)" ]; then echo -ne \"vim-->\t:!bash\n\" | sed 's|^|    |'; echo -ne \"vim-->\t:set shell=/bin/bash:shell\n\" | sed 's|^|    |'; fi; if [ -x "$(command -v awk)" ]; then echo -ne \"awk-->\tawk 'BEGIN {system(\"/bin/bash\")}'\n\" | sed 's|^|    |'; fi; if [ -x "$(command -v perl)" ]; then echo -ne \"perl-->\tperl -e 'exec \"/bin/bash\";'\n\" | sed 's|^|    |'; fi; if [ -x "$(command -v python)" ]; then echo -ne \"python-->\tpython -c '__import__(\"os\").system(\"/bin/bash\")'\n\" | sed 's|^|    |'; fi; if [ -x "$(command -v find)" ]; then echo -ne \"find->\tfind / -exec /usr/bin/awk 'BEGIN {system(\"/bin/bash\")}' \\;\n\" | sed 's|^|    |'; fi; if [ -x "$(command -v nmap)" ]; then echo -ne \"nmap-->\t--interactive\n\" | sed 's|^|    |'; fi";
+}
 
-if [ -x "$(command -v vim)" ]; then
-	echo -ne "vim-->\t:!bash\n" | sed 's|^|    |'
-	echo -ne "vim-->\t:set shell=/bin/bash:shell\n" | sed 's|^|    |'
-fi
+searchEXPLOITS(){
+  systemAREA="Search for Exploits";
+  systemAREAtitle;
 
-if [ -x "$(command -v awk)" ]; then
-	echo -ne "awk-->\tawk 'BEGIN {system(\"/bin/bash\")}'\n" | sed 's|^|    |'
-fi
+  echo -e "[*] FINDING RELEVANT PRIVILEGE ESCALATION EXPLOITS..."
+  read -p "[?] Would you like to search for possible exploits? [y/N] " connectToServer
 
-if [ -x "$(command -v perl)" ]; then
-	echo -ne "perl-->\tperl -e 'exec \"/bin/bash\";'\n" | sed 's|^|    |'
-fi
+  if [[ $connectToServer = y* ]]
+  then
+	   read -p "[?] What is the address of the server? " server
+	    read -p "[?] What port is the server using? " port
+	     echo -ne "\n\n"
+	      echo -e "[ ] Searching on $server:$port"
+	       printf "%*s\n" "80" | tr " " "*"
+	        dpkg -l | tail -n +6 | awk '{print $2, $3} END {print ""}' | nc $server $port
+	         printf "%*s\n" "80" | tr " " "*"
+  fi
+}
 
-if [ -x "$(command -v python)" ]; then
-	echo -ne "python-->\tpython -c '__import__(\"os\").system(\"/bin/bash\")'\n" | sed 's|^|    |'
-fi
+start(){
+  scriptTITLE;
+  operatingSYSTEM;
+  netWORK;
+  userENVIRONMENT;
+  filePERMISSIONS;
+  applicationSERVICES;
+  searchEXPLOITS;
+  echo ${titleLINE};
+  echo "         FINISHED"
+  echo -e ${titleLINE};
+  echo -e $RESET;
+}
 
-if [ -x "$(command -v find)" ]; then
-	echo -ne "find->\tfind / -exec /usr/bin/awk 'BEGIN {system(\"/bin/bash\")}' \\;\n" | sed 's|^|    |'
-fi
-
-if [ -x "$(command -v nmap)" ]; then
-	echo -ne "nmap-->\t--interactive\n" | sed 's|^|    |'
-fi
-
-echo -ne "\n${SECTION_LINE}\n"
-echo -e "[*] FINDING RELEVANT PRIVILEGE ESCALATION EXPLOITS..."
-read -p "[?] Would you like to search for possible exploits? [y/N] " connectToServer
-
-if [[ $connectToServer = y* ]]
-then
-	read -p "[?] What is the address of the server? " server
-	read -p "[?] What port is the server using? " port
-	echo -ne "\n\n"
-	echo -e "[ ] Searching on $server:$port"
-	printf "%*s\n" "80" | tr " " "*"
-	dpkg -l | tail -n +6 | awk '{print $2, $3} END {print ""}' | nc $server $port
-	printf "%*s\n" "80" | tr " " "*"
-fi
-
-echo -ne "\n\n${TITLE_LINE}"
-echo -ne "\nFINISHED"
-echo -ne "\n${TITLE_LINE}\n"
+start;

--- a/linuxprivchecker.sh
+++ b/linuxprivchecker.sh
@@ -36,40 +36,36 @@
 PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/games:/usr/games"
 
 # line formatting
-titleLINE=$(printf "%*s\n" "80" | tr ' ' "=");
-sectionLINE=$(printf "%*s\n" "40" | tr ' ' "-");
+LINE=$(printf "%*s\n" "80" | tr ' ' "#");
 
 # title
 scriptTITLE(){
-echo ${titleLINE};
-echo "         LINUX PRIVILEGE ESCALATION CHECKER"
-echo "         https://github.com/linted/linuxprivchecker for more info..."
-echo ${titleLINE};
+echo ${LINE};
+echo "    LINUX PRIVILEGE ESCALATION CHECKER"
+echo "    https://github.com/linted/linuxprivchecker for more info..."
+echo ${LINE};
+echo
 }
 
 systemAREAtitle(){
-  echo ${sectionLINE};
-  echo -e "         $systemAREA";
-  echo ${sectionLINE};
+  echo ${LINE};
+  echo -e "    $systemAREA";
+  echo ${LINE};
   echo
-  sleep .5s;
 }
 
 cmdRESPONSE(){
 	# run and format cmd
-  cmdRESULT=$(eval $1 2>/dev/null | sed 's|^|           |'; echo "${PIPESTATUS[0]}");
+  cmdRESULT=$(eval $1 2>/dev/null | sed 's|^|     |'; echo "${PIPESTATUS[0]}");
 
 	# check cmd status
   if [ ${cmdRESULT:(-1)} -eq 0 ]; then
-    echo "[OK]     $systemNAME";
+    echo "[+] $systemNAME";
     echo "${cmdRESULT%?}";
-    echo
   else
-    echo "[FAILED] $systemNAME";
+    echo "[-] $systemNAME";
     echo "${cmdRESULT%?}";
-    echo
   fi
-  sleep .5s;
 }
 
 operatingSYSTEM(){
@@ -212,7 +208,30 @@ applicationSERVICES(){
   cmdRESPONSE "which awk perl python ruby gcc cc vi vim nmap find netcat nc wget tftp ftp";
 
   systemNAME="Related Shell Escape Sequences";
-  cmdRESPONSE "if [ -x "$(command -v vi)" ]; then echo -ne \"vi-->\t:!bash\n\"; echo -ne \"vi-->\t:set shell=/bin/bash:shell\n\"; fi; if [ -x "$(command -v vim)" ]; then echo -ne \"vim-->\t:!bash\n\" | sed 's|^|    |'; echo -ne \"vim-->\t:set shell=/bin/bash:shell\n\" | sed 's|^|    |'; fi; if [ -x "$(command -v awk)" ]; then echo -ne \"awk-->\tawk 'BEGIN {system(\"/bin/bash\")}'\n\" | sed 's|^|    |'; fi; if [ -x "$(command -v perl)" ]; then echo -ne \"perl-->\tperl -e 'exec \"/bin/bash\";'\n\" | sed 's|^|    |'; fi; if [ -x "$(command -v python)" ]; then echo -ne \"python-->\tpython -c '__import__(\"os\").system(\"/bin/bash\")'\n\" | sed 's|^|    |'; fi; if [ -x "$(command -v find)" ]; then echo -ne \"find->\tfind / -exec /usr/bin/awk 'BEGIN {system(\"/bin/bash\")}' \\;\n\" | sed 's|^|    |'; fi; if [ -x "$(command -v nmap)" ]; then echo -ne \"nmap-->\t--interactive\n\" | sed 's|^|    |'; fi";
+  cmdRESPONSE "if [ -x "$(command -v vi)" ]; then \
+                  echo -ne \"vi-->\t:!bash\n\"; \
+                  echo -ne \"vi-->\t:set shell=/bin/bash:shell\n\"; \
+               fi; \
+               if [ -x "$(command -v vim)" ]; then \
+                  echo -ne \"vim-->\t:!bash\n\" | sed 's|^|    |'; \
+                  echo -ne \"vim-->\t:set shell=/bin/bash:shell\n\" | sed 's|^|    |'; \
+               fi; \
+               if [ -x "$(command -v awk)" ]; then \
+                  echo -ne \"awk-->\tawk 'BEGIN {system(\"/bin/bash\")}'\n\" | sed 's|^|    |'; \
+               fi; \
+               if [ -x "$(command -v perl)" ]; then \
+                  echo -ne \"perl-->\tperl -e 'exec \"/bin/bash\";'\n\" | sed 's|^|    |'; \
+               fi; \
+               if [ -x "$(command -v python)" ]; then \
+                  echo -ne \"python-->\tpython -c '__import__(\"os\").system(\"/bin/bash\")'\n\" | sed 's|^|    |'; \
+               fi; \
+               if [ -x "$(command -v find)" ]; then \
+                  echo -ne \"find->\tfind / -exec /usr/bin/awk 'BEGIN {system(\"/bin/bash\")}' \\;\n\" | sed 's|^|    |'; \
+               fi; \
+               if [ -x "$(command -v nmap)" ]; then \
+                  echo -ne \"nmap-->\t--interactive\n\" | sed 's|^|    |'; \
+               fi";
+
 }
 
 searchEXPLOITS(){
@@ -242,10 +261,10 @@ start(){
   filePERMISSIONS;
   applicationSERVICES;
   searchEXPLOITS;
-  echo ${titleLINE};
-  echo "         FINISHED"
-  echo -e ${titleLINE};
-  echo -e $RESET;
+  echo ${LINE};
+  echo "    FINISHED"
+  echo ${LINE};
+  echo
 }
 
 start;

--- a/linuxprivchecker.sh
+++ b/linuxprivchecker.sh
@@ -33,7 +33,7 @@
 ###############################################################################################################
 
 # command paths
-PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/games:/usr/games"
+PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/games:/usr/games";
 
 # line formatting
 LINE=$(printf "%*s\n" "80" | tr ' ' "#");


### PR DESCRIPTION
- updated version of Update linuxprivchecker.sh #8
- I removed colors for now because when you ">" output to a file, the color characters are present in that file and breaks things up.
- I changed [+] to OK and [-] to FAILED.  Since this is for the pentesting community, maybe we don't need OK/FAILED because [+] and [-] is understood?
- Fixed the Related Shell Escape Sequences issue
- Replaced printf with echo because it didn't play well with % in outputs from ${cmdRESULT%?}.
@5aru @linted 