### PR TITLE
Better exploit searching

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "exploitdb"]
-	path = exploitdb
-	url = https://github.com/mattoufoutu/exploitdb.git

--- a/privcheckerserver.py
+++ b/privcheckerserver.py
@@ -18,20 +18,24 @@ _searchsploit = ""
 
 class SearchHandler(socketserver.StreamRequestHandler):
     def handle(self):
-        print('[+] Connection from '+ self.client_address[0])
-        output = []
-        for data in iter(self.rfile.readline, ''):
-            term = data.decode().strip()
-            if re.search("^[\w\s:\-\+\._]+$", term):
-                print("[-] recieved search term with invalid characters: {}".format(term))
-                continue
+        try:
+            print('[+] Connection from '+ self.client_address[0])
+            output = []
+            for data in iter(self.rfile.readline, ''):
+                term = data.decode().strip()
+                if re.search("^[\w\s:\-\+\._]+$", term):
+                    print("[-] recieved search term with invalid characters: {}".format(term))
+                    continue
 
-            print('[ ] Searching for: ' + term)
-            splitTerms = term.split(" ")
-            splitTerms[-1] = splitTerms[-1][:3] #cut down on the last item which should be the version number
-            proc = subprocess.Popen([_searchsploit, *splitTerms], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-            self.wfile.write(b'{}\n'.format(proc.stdout.read().decode()))
-        print('[-] Closing connection from ' + self.client_address[0])
+                print('[ ] Searching for: ' + term)
+                splitTerms = term.split(" ")
+                splitTerms[-1] = splitTerms[-1][:3] #cut down on the last item which should be the version number
+                proc = subprocess.Popen([_searchsploit, *splitTerms], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                self.wfile.write(b'{}\n'.format(proc.stdout.read().decode()))
+            print('[-] Closing connection from ' + self.client_address[0])
+        except Exception as e:
+            print("[-] Caught exception {}. Closing this connection.".format(e))
+            self.wfile.write("[-] Server caught {}. Closing Connection".format(e).decode())
         
 
 

--- a/privcheckerserver.py
+++ b/privcheckerserver.py
@@ -31,7 +31,7 @@ class SearchHandler(socketserver.StreamRequestHandler):
                         break #bad term break so we don't search it
                 else:
                     print('[ ] Searching for: {}'.format(' '.join(term)))
-                    proc = subprocess.Popen([_searchsploit, '-j', *splitTerms], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                    proc = subprocess.Popen([_searchsploit, '-j', *term], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                     output = proc.stdout.read()
                     if json.loads(output).get("results", False):
                         self.wfile.write(output.encode())

--- a/privcheckerserver.py
+++ b/privcheckerserver.py
@@ -23,7 +23,7 @@ class SearchHandler(socketserver.StreamRequestHandler):
         try:
             print('[+] Connection from '+ self.client_address[0])
             self.pool = multiprocessing.Pool(5)
-            for output in p.imap_unordered(self.search, iter(str(self.rfile.readline), '\n')):
+            for output in self.pool.imap_unordered(self.search, iter(str(self.rfile.readline), '\n')):
                 if not output[0]:
                     #error'd out. print the results, but don't send them on?
                     print(output[1])

--- a/privcheckerserver.py
+++ b/privcheckerserver.py
@@ -37,6 +37,8 @@ class ExploitServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
     
 
 def main():
+    global _IP_
+    global _PORT_
     #parse the args
     parser = argparse.ArgumentParser()
     parser.add_argument("-i", "--ip", help="Ip to listen on")
@@ -63,4 +65,5 @@ def main():
         exploit.server_close()
     
 if __name__ == "__main__":
+    print("[ ] Starting up")
     main()

--- a/privcheckerserver.py
+++ b/privcheckerserver.py
@@ -29,7 +29,7 @@ class SearchHandler(socketserver.StreamRequestHandler):
                         print("[-] recieved search term with invalid characters: {}".format(splitTerms))
                         break #bad term break so we don't search it
                 else:
-                    print('[ ] Searching for: {}'.format(' '.join(term)
+                    print('[ ] Searching for: {}'.format(' '.join(term))
                     proc = subprocess.Popen([_searchsploit, *splitTerms], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                     self.wfile.write('{}\n'.format(proc.stdout.read()).encode())
 

--- a/privcheckerserver.py
+++ b/privcheckerserver.py
@@ -31,8 +31,8 @@ class SearchHandler(socketserver.StreamRequestHandler):
                 splitTerms = term.split(" ")
                 splitTerms[-1] = splitTerms[-1][:3] #cut down on the last item which should be the version number
                 proc = subprocess.Popen([_searchsploit, *splitTerms], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-                self.wfile.write('{}\n'.format(proc.stdout.read())
-            print('[-] Closing connection from ' + self.client_address[0])
+                self.wfile.write('{}\n'.format(proc.stdout.read()))
+            print('[$] Closing connection from {}\n'.format(self.client_address[0]))
         except Exception as e:
             print("[-] Caught exception {}. Closing this connection.".format(e))
             self.wfile.write("[-] Server caught {}. Closing Connection".format(e))

--- a/privcheckerserver.py
+++ b/privcheckerserver.py
@@ -31,11 +31,11 @@ class SearchHandler(socketserver.StreamRequestHandler):
                 splitTerms = term.split(" ")
                 splitTerms[-1] = splitTerms[-1][:3] #cut down on the last item which should be the version number
                 proc = subprocess.Popen([_searchsploit, *splitTerms], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-                self.wfile.write('{}\n'.format(proc.stdout.read()))
+                self.wfile.write('{}\n'.format(proc.stdout.read()).encode())
             print('[$] Closing connection from {}\n'.format(self.client_address[0]))
         except Exception as e:
             print("[-] Caught exception {}. Closing this connection.".format(e))
-            self.wfile.write("[-] Server caught {}. Closing Connection".format(e))
+            self.wfile.write("[-] Server caught {}. Closing Connection".format(e).encode())
         
 
 

--- a/privcheckerserver.py
+++ b/privcheckerserver.py
@@ -35,6 +35,9 @@ class SearchHandler(socketserver.StreamRequestHandler):
                     print('[-] No results for: {}'.format(' '.join(term)))
 
             print('[$] Closing connection from {}\n'.format(self.client_address[0]))
+        except Exception as e:
+            self.wfile.write(b'{{"SEARCH":"ERROR", "RESULTS":"{}"}}'.format(e))
+            print("[-] Exception Caught: {}".format(e))
 
     def search(data):
         try:

--- a/privcheckerserver.py
+++ b/privcheckerserver.py
@@ -22,7 +22,8 @@ class SearchHandler(socketserver.StreamRequestHandler):
         output = []
         for data in iter(self.rfile.readline, ''):
             term = data.decode().strip()
-            if not re.search("^[\w\s]+$", term):
+            if re.search("^[\w\s\-\+\._]+$", term):
+                print("[-] recieved search term with invalid characters: {}".format(term))
                 continue
 
             print('[ ] Searching for: ' + term)
@@ -37,18 +38,6 @@ class ExploitServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
     
 
 def main():
-    global _IP_
-    global _PORT_
-    #parse the args
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-i", "--ip", help="Ip to listen on")
-    parser.add_argument("-p", "--port", help="Port to listen on")
-    args = parser.parse_args()
-    if args.ip:
-        _IP_ = args.ip
-    if args.port:
-        _PORT_ = args.port
-
     #make sure we have searchsploit accessable
     _searchsploit = which("searchsploit")
     if not _searchsploit:
@@ -65,5 +54,15 @@ def main():
         exploit.server_close()
     
 if __name__ == "__main__":
+    #parse the args
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", "--ip", help="Ip to listen on")
+    parser.add_argument("-p", "--port", help="Port to listen on")
+    args = parser.parse_args()
+    if args.ip:
+        _IP_ = args.ip
+    if args.port:
+        _PORT_ = args.port
+
     print("[ ] Starting up")
     main()

--- a/privcheckerserver.py
+++ b/privcheckerserver.py
@@ -22,12 +22,12 @@ class SearchHandler(socketserver.StreamRequestHandler):
         output = []
         for data in iter(self.rfile.readline, ''):
             term = data.decode().strip()
-            if re.search("^[\w\s\-\+\._]+$", term):
+            if re.search("^[\w\s:\-\+\._]+$", term):
                 print("[-] recieved search term with invalid characters: {}".format(term))
                 continue
 
             print('[ ] Searching for: ' + term)
-            proc = subprocess.Popen([_searchsploit, term.split(" ")], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            proc = subprocess.Popen([_searchsploit, *term.split(" ")], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             self.wfile.write(b'{}\n'.format(proc.stdout.read().decode()))
         print('[-] Closing connection from ' + self.client_address[0])
         

--- a/privcheckerserver.py
+++ b/privcheckerserver.py
@@ -31,11 +31,11 @@ class SearchHandler(socketserver.StreamRequestHandler):
                 splitTerms = term.split(" ")
                 splitTerms[-1] = splitTerms[-1][:3] #cut down on the last item which should be the version number
                 proc = subprocess.Popen([_searchsploit, *splitTerms], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-                self.wfile.write(b'{}\n'.format(proc.stdout.read().decode()))
+                self.wfile.write('{}\n'.format(proc.stdout.read())
             print('[-] Closing connection from ' + self.client_address[0])
         except Exception as e:
             print("[-] Caught exception {}. Closing this connection.".format(e))
-            self.wfile.write("[-] Server caught {}. Closing Connection".format(e).decode())
+            self.wfile.write("[-] Server caught {}. Closing Connection".format(e))
         
 
 

--- a/privcheckerserver.py
+++ b/privcheckerserver.py
@@ -7,6 +7,7 @@ try:
     import argparse
     import re
     import subprocess
+    import json
 except Exception as e:
     print("Caught exception: {}\nAre you running with python3?".format(e))
     exit(1)
@@ -30,8 +31,10 @@ class SearchHandler(socketserver.StreamRequestHandler):
                         break #bad term break so we don't search it
                 else:
                     print('[ ] Searching for: {}'.format(' '.join(term)))
-                    proc = subprocess.Popen([_searchsploit, *splitTerms], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-                    self.wfile.write('{}\n'.format(proc.stdout.read()).encode())
+                    proc = subprocess.Popen([_searchsploit, '-j', *splitTerms], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                    output = proc.stdout.read()
+                    if json.loads(output).get("results", False):
+                        self.wfile.write(output.encode())
 
             print('[$] Closing connection from {}\n'.format(self.client_address[0]))
         except Exception as e:

--- a/privcheckerserver.py
+++ b/privcheckerserver.py
@@ -31,7 +31,7 @@ class SearchHandler(socketserver.StreamRequestHandler):
             self.pool.join()
         except Exception as e:
             self.pool.terminate()
-            self.wfile.write('{{"SEARCH":"ERROR", "RESULTS":"{}"}}'.format(e).encode())
+            self.wfile.write('[-] Exception Caught: {}'.format(e).encode())
             print("[-] Exception Caught: {}".format(e))
             self.pool.join()
 
@@ -44,7 +44,7 @@ class SearchHandler(socketserver.StreamRequestHandler):
             if all([term in rows["description"] for term in query]):
                 output.append('\t'.join((rows["description"], rows["file"])))
         if output:
-            return "\n".join(("[ ] " + query, *output))
+            return "[ ] " + "\n".join([' '.join(query), *output])
 
 
 

--- a/privcheckerserver.py
+++ b/privcheckerserver.py
@@ -25,8 +25,8 @@ class SearchHandler(socketserver.StreamRequestHandler):
                 term = data.decode().strip().split(" ")
                 term[-1] = term[-1][:3] #cut down on the last item which should be the version number
                 for splitTerms in term:
-                    if not re.search("^[\w\s:\-\+\.~_]+$", term):
-                        print("[-] recieved search term with invalid characters: {}".format(term))
+                    if not re.search("^[\w\s:\-\+\.~_]+$", splitTerms):
+                        print("[-] recieved search term with invalid characters: {}".format(splitTerms))
                         break #bad term break so we don't search it
                 else:
                     print('[ ] Searching for: ' + term)

--- a/privcheckerserver.py
+++ b/privcheckerserver.py
@@ -27,7 +27,9 @@ class SearchHandler(socketserver.StreamRequestHandler):
                 continue
 
             print('[ ] Searching for: ' + term)
-            proc = subprocess.Popen([_searchsploit, *term.split(" ")], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            splitTerms = term.split(" ")
+            splitTerms[-1] = splitTerms[-1][:3] #cut down on the last item which should be the version number
+            proc = subprocess.Popen([_searchsploit, *splitTerms], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             self.wfile.write(b'{}\n'.format(proc.stdout.read().decode()))
         print('[-] Closing connection from ' + self.client_address[0])
         

--- a/privcheckerserver.py
+++ b/privcheckerserver.py
@@ -29,7 +29,7 @@ class SearchHandler(socketserver.StreamRequestHandler):
                         print("[-] recieved search term with invalid characters: {}".format(splitTerms))
                         break #bad term break so we don't search it
                 else:
-                    print('[ ] Searching for: {}'.format(' '.join(term))
+                    print('[ ] Searching for: {}'.format(' '.join(term)))
                     proc = subprocess.Popen([_searchsploit, *splitTerms], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                     self.wfile.write('{}\n'.format(proc.stdout.read()).encode())
 

--- a/privcheckerserver.py
+++ b/privcheckerserver.py
@@ -26,10 +26,9 @@ class SearchHandler(socketserver.StreamRequestHandler):
                     print(output)
                     self.wfile.write(output.encode())
                 
-
             self.pool.close()
-            self.pool.join()
             print('[$] Closing connection from {}\n'.format(self.client_address[0]))
+            self.pool.join()
         except Exception as e:
             self.pool.terminate()
             self.wfile.write('{{"SEARCH":"ERROR", "RESULTS":"{}"}}'.format(e).encode())
@@ -66,8 +65,8 @@ def main():
 if __name__ == "__main__":
     #parse the args
     parser = argparse.ArgumentParser()
-    parser.add_argument("-i", "--ip", help="Ip to listen on", required=True)
-    parser.add_argument("-p", "--port", help="Port to listen on", required=True)
+    parser.add_argument("-i", "--ip", help="Ip to listen on")
+    parser.add_argument("-p", "--port", help="Port to listen on")
     parser.add_argument("-f", "--file", help="The exploit csv to use")
     args = parser.parse_args()
     if args.ip:

--- a/privcheckerserver.py
+++ b/privcheckerserver.py
@@ -23,7 +23,7 @@ class SearchHandler(socketserver.StreamRequestHandler):
         try:
             print('[+] Connection from '+ self.client_address[0])
             p = multiprocessing.Pool(5)
-            for output in p.imap_unordered(self.search, iter(self.rfile.readline, b'\n')):
+            for output in p.imap_unordered(self.search, iter(str(self.rfile.readline), '\n')):
                 if not output[0]:
                     #error'd out. print the results, but don't send them on?
                     print(output[1])
@@ -36,7 +36,7 @@ class SearchHandler(socketserver.StreamRequestHandler):
 
             print('[$] Closing connection from {}\n'.format(self.client_address[0]))
         except Exception as e:
-            self.wfile.write(b'{{"SEARCH":"ERROR", "RESULTS":"{}"}}'.format(e))
+            self.wfile.write('{{"SEARCH":"ERROR", "RESULTS":"{}"}}'.format(e).decode())
             print("[-] Exception Caught: {}".format(e))
 
     def search(data):

--- a/privcheckerserver.py
+++ b/privcheckerserver.py
@@ -29,7 +29,7 @@ class SearchHandler(socketserver.StreamRequestHandler):
                         print("[-] recieved search term with invalid characters: {}".format(splitTerms))
                         break #bad term break so we don't search it
                 else:
-                    print('[ ] Searching for: ' + term)
+                    print('[ ] Searching for: {}'.format(' '.join(term)
                     proc = subprocess.Popen([_searchsploit, *splitTerms], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                     self.wfile.write('{}\n'.format(proc.stdout.read()).encode())
 

--- a/privcheckerserver.py
+++ b/privcheckerserver.py
@@ -23,19 +23,17 @@ class SearchHandler(socketserver.StreamRequestHandler):
             output = []
             for data in iter(self.rfile.readline, ''):
                 term = data.decode().strip()
-                if re.search("^[\w\s:\-\+\._]+$", term):
+                if not re.search("^[\w\s:\-\+\.~_]+$", term):
                     print("[-] recieved search term with invalid characters: {}".format(term))
                     continue
 
                 print('[ ] Searching for: ' + term)
-                splitTerms = term.split(" ")
-                splitTerms[-1] = splitTerms[-1][:3] #cut down on the last item which should be the version number
                 proc = subprocess.Popen([_searchsploit, *splitTerms], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                 self.wfile.write('{}\n'.format(proc.stdout.read()).encode())
             print('[$] Closing connection from {}\n'.format(self.client_address[0]))
         except Exception as e:
             print("[-] Caught exception {}. Closing this connection.".format(e))
-            self.wfile.write("[-] Server caught {}. Closing Connection".format(e).encode())
+            self.wfile.write("[-] Server caught {}. Closing Connection\n".format(e).encode())
         
 
 

--- a/privcheckerserver.py
+++ b/privcheckerserver.py
@@ -42,7 +42,7 @@ class SearchHandler(socketserver.StreamRequestHandler):
         output = []
         for rows in ExploitServer.exploitDatabase:
             if all([term in rows["description"] for term in query]):
-                output.append('\t'.join((rows["description"], rows["file"]))
+                output.append('\t'.join((rows["description"], rows["file"])))
         if output:
             return "\n".join(("[ ] " + query, *output)
 

--- a/privcheckerserver.py
+++ b/privcheckerserver.py
@@ -24,7 +24,7 @@ class SearchHandler(socketserver.StreamRequestHandler):
             for output in self.pool.imap(SearchHandler.search, iter(self.rfile.readline, b'\n')):
                 if output:
                     print(output)
-                    self.wfile.write(output.encode())
+                    self.wfile.write(output.encode() + b'\n')
                 
             self.pool.close()
             print('[$] Closing connection from {}\n'.format(self.client_address[0]))
@@ -39,12 +39,12 @@ class SearchHandler(socketserver.StreamRequestHandler):
     def search(cls, data):
         query = data.decode().strip().split(" ")
         query[-1] = query[-1][:3] #cut down on the last item which should be the version number
-        output = ["[ ]" + data]
+        output = []
         for rows in ExploitServer.exploitDatabase:
             if all([term in rows["description"] for term in query]):
-                output.append('\t | '.join(rows["description"], rows["file"]))
+                output.append('\t'.join((rows["description"], rows["file"]))
         if output:
-            return "\n".join(output)
+            return "\n".join(("[ ] " + query, *output)
 
 
 

--- a/privcheckerserver.py
+++ b/privcheckerserver.py
@@ -44,7 +44,7 @@ class SearchHandler(socketserver.StreamRequestHandler):
             if all([term in rows["description"] for term in query]):
                 output.append('\t'.join((rows["description"], rows["file"])))
         if output:
-            return "\n".join(("[ ] " + query, *output)
+            return "\n".join(("[ ] " + query, *output))
 
 
 


### PR DESCRIPTION
**TL;DR**
- Removed abandoned dependency
- Multi-threading search of exploit db
- No longer needs to download exploitdb, and supports custom path to the database

This branch removes the abandoned dependency we were using to parse exploitdb. The major reason for moving away from that dependency is due to the change in structure of exploitdb's archive. The new parsing method uses kali's built in searchsploit database, and also supports custom csv files locations. Since we are doing the parsing ourself now, the multithreading library speeds up the process by running 10 threads at once in a pool doing the searches. In the future we can add a `-j` option to configure the number of jobs, but that is for another pull request.